### PR TITLE
zon2json-lock: resolve dependencies where path is relative

### DIFF
--- a/tools/zon2json-lock.nix
+++ b/tools/zon2json-lock.nix
@@ -115,8 +115,10 @@ writeShellApplication {
 
       # Go through path deps as well in case they have network deps
       while read -r path_dep; do
-        if [[ -f "$path_dep/build.zig.zon" ]]; then
-          zon2json-recursive "$path_dep/build.zig.zon"
+        directory=$(dirname "$1")
+        resolvedPath=$(realpath "$directory/$path_dep")
+        if [[ -f "$resolvedPath/build.zig.zon" ]]; then
+          zon2json-recursive "$resolvedPath/build.zig.zon"
         fi
       done < <(zon2json "$1" | jq -r '.dependencies | to_entries | .[] | select(.value.path != null) | .value.path' 2>/dev/null)
     }


### PR DESCRIPTION
`build.zig.zon` dependencies can contain relative path references. For example a `<project root>/pkg/<example>/build.zig.zon` file containing the following:

```zig
.{
    .name = "<example>",
    .version = "<version>",
    .dependencies = .{
        .libxml2 = .{ .path = "../libxml2" },
    },
}
```

The current script appears to roughly test if `<project root>/../libxml2/build.zig.zon` is a file and won't find the it. Instead we need to resolve the directory of the currently processed `build.zig.zon` and look relative to that. 

Here's an attempt to do that just editing `tools/zon2json-lock.nix`. Perhaps there's a better solution.