### PR TITLE
fix: /tmp is a symlink on macos

### DIFF
--- a/tools/zon2json-lock.nix
+++ b/tools/zon2json-lock.nix
@@ -21,7 +21,7 @@ writeShellApplication {
         error 'file does not exist: %s' "$path"
     fi
 
-    tmpdir="$(mktemp -d)"
+    tmpdir=$(realpath "$(mktemp -d)")
     trap 'rm -rf "$tmpdir"' EXIT
     read -r zig_cache < <(zig env | jq -er '.global_cache_dir')
 

--- a/tools/zon2json-lock.nix
+++ b/tools/zon2json-lock.nix
@@ -7,11 +7,12 @@
   , coreutils
   , findutils
   , nix-prefetch-git
+  , nix
 }:
 
 writeShellApplication {
   name = "zon2json-lock";
-  runtimeInputs = [ zon2json jq zig curl findutils coreutils nix-prefetch-git ];
+  runtimeInputs = [ zon2json jq zig curl findutils coreutils nix-prefetch-git nix ];
   text = ''
     # shellcheck disable=SC2059
     error() { printf -- "error: $1\n" "''${@:2}" 1>&2; exit 1; }
@@ -89,7 +90,7 @@ writeShellApplication {
                 ;;
               http://*|https://*)
                 curl -sSL "$url" -o "$tmpdir/$zhash.artifact"
-                ahash="$(nix hash path --mode flat /dev/stdin < "$tmpdir/$zhash.artifact")"
+                ahash="$(cd "$tmpdir"; nix hash path --mode flat "$zhash.artifact")"
                 rm -f "$tmpdir/$zhash.artifact"
                 ;;
               *)

--- a/tools/zon2json-lock.nix
+++ b/tools/zon2json-lock.nix
@@ -87,9 +87,9 @@ writeShellApplication {
                 ahash="$(git-prefetch "$url" | jq -er '.hash')"
                 rm -rf "$tmpdir/$zhash.git"
                 ;;
-              file://*|http://*|https://*)
+              http://*|https://*)
                 curl -sSL "$url" -o "$tmpdir/$zhash.artifact"
-                ahash="$(nix hash file "$tmpdir/$zhash.artifact")"
+                ahash="$(nix hash path --mode flat /dev/stdin < "$tmpdir/$zhash.artifact")"
                 rm -f "$tmpdir/$zhash.artifact"
                 ;;
               *)


### PR DESCRIPTION
On macOS `/tmp` is symlinked to `/private/tmp`. Nix does not seem to like that. The fix is to simply resolve the path with realpath. I am not 100% sure of any implications this change has, but it fixed my specific use case. I haven't tested in on Linux tho.