### PR TITLE
ensure `zig2nix` and `loader` are built with latest stable zig, not master

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -188,7 +188,9 @@
         package = zigPackage;
 
         #! Bundle a package into a zip
-        bundle.zip = pkgs.callPackage ./src/bundle/zip.nix { inherit zigPackage; };
+        bundle.zip = pkgs.callPackage ./src/bundle/zip.nix {
+          zigPackage = (zig-env { zig = zigv.latest; }).package;
+        };
 
         #! Bundle a package for running in AWS lambda
         bundle.aws.lambda = pkgs.callPackage ./src/bundle/lambda.nix { bundleZip = bundle.zip; };
@@ -198,9 +200,10 @@
       test-app = test-env.app-bare;
 
       test = removeAttrs (_callPackage src/test.nix {
-        inherit test-app;
+        inherit test-app zig2nix-zigless;
         inherit (test-env) zig zig2nix target deriveLockFile;
         zig-env = test-env;
+        zig-stable-env = zig-env {};
       }) [ "override" "overrideDerivation" "overrideAttrs" ];
 
       flake-outputs = _callPackage (import ./src/zig/outputs.nix) {

--- a/src/test.nix
+++ b/src/test.nix
@@ -2,7 +2,9 @@
   lib
   , test-app
   , zig-env
+  , zig-stable-env
   , zig2nix
+  , zig2nix-zigless
   , jq
   , findutils
   , coreutils
@@ -76,7 +78,7 @@ with lib;
 
   # nix run .#test-package
   package = let
-    pkg = zig-env.package {
+    pkg = zig-stable-env.package {
       name = "zig2nix";
       src = cleanSource ../src/zig2nix;
     };
@@ -85,14 +87,14 @@ with lib;
   # nix run .#test-bundle
   bundle = let
     zip1 = zig-env.bundle.zip {
-      package = zig-env.package {
+      package = zig-stable-env.package {
         name = "zig2nix";
         src = cleanSource ../src/zig2nix;
         meta.mainProgram = "zig2nix";
       };
     };
     zip2 = zig-env.bundle.zip {
-      package = zig-env.package {
+      package = zig-stable-env.package {
         name = "zig2nix";
         src = cleanSource ../src/zig2nix;
         meta.mainProgram = "zig2nix";
@@ -100,7 +102,7 @@ with lib;
       packageAsRoot = true;
     };
     lambda = zig-env.bundle.aws.lambda {
-      package = zig-env.package {
+      package = zig-stable-env.package {
         zigTarget = "aarch64-linux-musl";
         name = "zig2nix";
         src = cleanSource ../src/zig2nix;

--- a/src/zig/versions.nix
+++ b/src/zig/versions.nix
@@ -17,153 +17,153 @@ let
   src = release: llvmPackages: zigSrc { inherit zigHook release llvmPackages; };
 
   meta-master = {
-    version = "0.15.0-dev.936+fc2c1883b";
-    date = "2025-07-08";
+    version = "0.15.0-dev.1034+bd97b6618";
+    date = "2025-07-12";
     docs = "https://ziglang.org/documentation/master/";
     stdDocs = "https://ziglang.org/documentation/master/std/";
 
     src = {
-      tarball = "https://ziglang.org/builds/zig-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "ce2a834f5fcef45fb07a8004c271e10de4532cd74be868672caa56580b938dc4";
-      size = 21341800;
+      tarball = "https://ziglang.org/builds/zig-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "f32185bfa243c8f707e7ed996ddeec218570461bfea64513c69e1f5dc53c86aa";
+      size = 21356556;
     };
 
     bootstrap = {
-      tarball = "https://ziglang.org/builds/zig-bootstrap-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "17b2041b837ba1797fda7c01b2ed3767f850af4f3df76123bcd165c88ee4b3db";
-      size = 52706484;
+      tarball = "https://ziglang.org/builds/zig-bootstrap-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "96ea4575ca837affd10eca539dd5dc3c3fe9f080bb18c309c11e65659076f72d";
+      size = 52725664;
     };
 
     x86_64-darwin = {
-      tarball = "https://ziglang.org/builds/zig-x86_64-macos-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "c3314719f0c3ddb69083e52c53ab1fd70d2f4bc3b4bb9454b9754e6ead8aa0e5";
-      size = 55615856;
+      tarball = "https://ziglang.org/builds/zig-x86_64-macos-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "4ab98fe79fa0cc32b4d2cd20702303f507670f90daec536ae93b963e20771684";
+      size = 55656500;
     };
 
     arm64-darwin = {
-      tarball = "https://ziglang.org/builds/zig-aarch64-macos-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "c8794a6bf88420dc86df3ec1f06bab9377a30d08a4616b46cdb0adfe9731ed74";
-      size = 50463708;
+      tarball = "https://ziglang.org/builds/zig-aarch64-macos-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "2571bcc4425eb07fb5f15a3ec1c74abd24411c3611483b4875b976284d987455";
+      size = 50513616;
     };
 
     x86_64-linux = {
-      tarball = "https://ziglang.org/builds/zig-x86_64-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "471ddd5382da3732bfe6f1253f9e0ddcc6e55edfb5a59e9ee5ca2012f80753cd";
-      size = 53564696;
+      tarball = "https://ziglang.org/builds/zig-x86_64-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "326883901c970f16c33a587bca44b26271c84d28d166e18f1411ef4a37fe8b53";
+      size = 53603364;
     };
 
     aarch64-linux = {
-      tarball = "https://ziglang.org/builds/zig-aarch64-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "1fce825d9d4559459a5c3bfdcf9c9aa5e905ea2e679753b5403b28d6339b7883";
-      size = 49327928;
+      tarball = "https://ziglang.org/builds/zig-aarch64-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "f2bdbfca92aaae755e7047bb73980fb8ef12c7920bc8165a5cf11bc996d3d97d";
+      size = 49370384;
     };
 
     armv7l-linux = {
-      tarball = "https://ziglang.org/builds/zig-arm-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "1d54733bb38fb3112d4754ee2e3a3cb53650819e29dc3fe66194d9ec621fa36d";
-      size = 50252240;
+      tarball = "https://ziglang.org/builds/zig-arm-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "f8ccb3761d37a8b2edea734068b344272176dd8e298c682d134a2708411c7443";
+      size = 50284360;
     };
 
     riscv64-linux = {
-      tarball = "https://ziglang.org/builds/zig-riscv64-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "73dbb4a4d844914bef64ad552c30cc896197380bdcf35f20cf38613eef1ccc15";
-      size = 53476912;
+      tarball = "https://ziglang.org/builds/zig-riscv64-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "18673a0552957309e7fce26ef41a8d3a7910553c664a9d8fa12ca0e56ca6a6c1";
+      size = 53487740;
     };
 
     powerpc64le-linux = {
-      tarball = "https://ziglang.org/builds/zig-powerpc64le-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "ef42cb157da2f27713a930f716eea72378b045b431b1f8ec7b33e9fc915a767f";
-      size = 53403384;
+      tarball = "https://ziglang.org/builds/zig-powerpc64le-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "a8f30f4aa438dddd005d88f6e03fed0d0534f8d668f5aae8157445c69a54c957";
+      size = 53451980;
     };
 
     i686-linux = {
-      tarball = "https://ziglang.org/builds/zig-x86-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "2a15786716d016245fe72704bca674f1fd2219cfcdb17b6ea6adfbdd0f90b38a";
-      size = 56134920;
+      tarball = "https://ziglang.org/builds/zig-x86-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "1d9c54af161fe7452b37146746421be4e7364ba031cfb27a2f0364b68a4ebca3";
+      size = 56172876;
     };
 
     loongarch64-linux = {
-      tarball = "https://ziglang.org/builds/zig-loongarch64-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "25dc04a33ea75315dc0ea97d4d02175e4530e05939d7238b97cb98c9ebc4e7db";
-      size = 50675280;
+      tarball = "https://ziglang.org/builds/zig-loongarch64-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "f1e2bcbdb809f1822b7b45b5670ee8411604a18c66c66d85b3b8609dcbb647bf";
+      size = 50698104;
     };
 
     s390x-linux = {
-      tarball = "https://ziglang.org/builds/zig-s390x-linux-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "685ff191e9457fc6681518c9f98dcb04c229d3e1650d522a9eeab33ce135452a";
-      size = 53215184;
+      tarball = "https://ziglang.org/builds/zig-s390x-linux-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "af66915e0148db507eface4a46171192585a052de4ae350c5fef38130d87efe3";
+      size = 53382292;
     };
 
     x86_64-mingw32 = {
-      tarball = "https://ziglang.org/builds/zig-x86_64-windows-0.15.0-dev.936+fc2c1883b.zip";
-      shasum = "bab78dc7e5180c6aae1f7dc24aaa8c013e78e1b5fb21f5a012af305038500134";
-      size = 93040926;
+      tarball = "https://ziglang.org/builds/zig-x86_64-windows-0.15.0-dev.1034+bd97b6618.zip";
+      shasum = "370c6d972d2ea7546fd4fd1680d6334ead75362741bf976af13d9ef4674aa7d1";
+      size = 93186206;
     };
 
     aarch64-mingw32 = {
-      tarball = "https://ziglang.org/builds/zig-aarch64-windows-0.15.0-dev.936+fc2c1883b.zip";
-      shasum = "8ee17fa37a3a7d51313abe016fc95d189667531be9fd5ae2545e252d57c2fa25";
-      size = 88937856;
+      tarball = "https://ziglang.org/builds/zig-aarch64-windows-0.15.0-dev.1034+bd97b6618.zip";
+      shasum = "04944651dba008363d29dcc53cee7ac465f156f59a50f6f890c34fa4f4bc29bf";
+      size = 89077030;
     };
 
     i686-mingw32 = {
-      tarball = "https://ziglang.org/builds/zig-x86-windows-0.15.0-dev.936+fc2c1883b.zip";
-      shasum = "fa50df5da7598593a28a147739cc98298c00f3baa062fcf2c6dee252b42d776b";
-      size = 94986423;
+      tarball = "https://ziglang.org/builds/zig-x86-windows-0.15.0-dev.1034+bd97b6618.zip";
+      shasum = "f91ea4d8670353629e66b07654d5e3dbdf5e9134de9fd6f374212bb87f4863a8";
+      size = 95108812;
     };
 
     aarch64-freebsd = {
-      tarball = "https://ziglang.org/builds/zig-aarch64-freebsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "eba233e243543fac987761c312433408cb4db77b1eedf040394437e003e84db1";
-      size = 49247340;
+      tarball = "https://ziglang.org/builds/zig-aarch64-freebsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "d7279771767c462cdb8737cc2f24dac0351049332b8f8737753f815e1c92558f";
+      size = 49279256;
     };
 
     powerpc64-freebsd = {
-      tarball = "https://ziglang.org/builds/zig-powerpc64-freebsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "928e1b5bd74b59413251bd340bbd2f8b9a56bd8a5830e3b62da3cfe07f64fd39";
-      size = 51993188;
+      tarball = "https://ziglang.org/builds/zig-powerpc64-freebsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "4c44f6d82e9996d58ce7548a8a0da3cdd1789ef8ca43bb3bfa9f962307a986ed";
+      size = 52024284;
     };
 
     powerpc64le-freebsd = {
-      tarball = "https://ziglang.org/builds/zig-powerpc64le-freebsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "6a0f973d7686f2101b8366b30b18f07c2025f1533493b6c3feb7f50ea4155abd";
-      size = 53328888;
+      tarball = "https://ziglang.org/builds/zig-powerpc64le-freebsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "d61466f7eb0b777a86c7b76e4db1a01637cfb3402922f4bd7cd5bf19a5630e81";
+      size = 53384472;
     };
 
     riscv64-freebsd = {
-      tarball = "https://ziglang.org/builds/zig-riscv64-freebsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "754f23e044f9255d1ac5d9358e6ea376b6afeb78659c4173657cce13b9fe7a66";
-      size = 53551760;
+      tarball = "https://ziglang.org/builds/zig-riscv64-freebsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "0a25fb398e3df92b2e42a8be4b19c2d40298337e6ae4341abeca9227e63adf73";
+      size = 53532996;
     };
 
     x86_64-freebsd = {
-      tarball = "https://ziglang.org/builds/zig-x86_64-freebsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "1d0c4e1af0df037d9dc782a5a61519eacddfdfe9c4ed9f29b2403ceffc6823c5";
-      size = 53641888;
+      tarball = "https://ziglang.org/builds/zig-x86_64-freebsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "5f1d832753c5dad1d476b89cabd38a2815c9937e1e3fe89dcc0269eaa49d5b89";
+      size = 53655584;
     };
 
     aarch64-netbsd = {
-      tarball = "https://ziglang.org/builds/zig-aarch64-netbsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "2ad4da99a36f2f7474570a2dca2382349bf17695abc24ac68de5bc11beec1c93";
-      size = 49250464;
+      tarball = "https://ziglang.org/builds/zig-aarch64-netbsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "77b680d681f06fa7d27b82f58b01f49a5f1b74baad2d20997630df0e03cb1c20";
+      size = 49283052;
     };
 
     armv7l-netbsd = {
-      tarball = "https://ziglang.org/builds/zig-arm-netbsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "6c30a867414760604734e109416f23a2ec8f46d23d8325357cbc9fa5d08a2076";
-      size = 51825740;
+      tarball = "https://ziglang.org/builds/zig-arm-netbsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "518799b10f76ee5a0cad7164c9b60abd50fc7170976769561a10b2e6c47faca9";
+      size = 51859476;
     };
 
     i686-netbsd = {
-      tarball = "https://ziglang.org/builds/zig-x86-netbsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "79036f10acfd008b989cc98344a611bc1a4f787f6d85c4638191aecddcb8d035";
-      size = 56738544;
+      tarball = "https://ziglang.org/builds/zig-x86-netbsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "2158714710c2b8c19bc29e6fb668c3291638d0b0c257d1e30a88c8e5ec63bd73";
+      size = 56771188;
     };
 
     x86_64-netbsd = {
-      tarball = "https://ziglang.org/builds/zig-x86_64-netbsd-0.15.0-dev.936+fc2c1883b.tar.xz";
-      shasum = "7f2924c225f174bbbe7bff04786adbe129b0570e446d39b8e96a9ac86830ddcc";
-      size = 53635864;
+      tarball = "https://ziglang.org/builds/zig-x86_64-netbsd-0.15.0-dev.1034+bd97b6618.tar.xz";
+      shasum = "1a151b83aedd27793e2e888134b2abee6bb91a05d36bceac0a259e3cb2aadaf4";
+      size = 53648888;
     };
   };
 

--- a/src/zig2nix/build.zig
+++ b/src/zig2nix/build.zig
@@ -4,12 +4,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "zig2nix",
+    const mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .single_threaded = true,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "zig2nix",
+        .root_module = mod,
     });
 
     b.installArtifact(exe);
@@ -20,10 +24,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
-        .single_threaded = true,
+        .root_module = mod,
     });
 
     const run_unit_tests = b.addRunArtifact(unit_tests);

--- a/templates/master/build.zig.zon
+++ b/templates/master/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x2d09a3d611111111, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.0-dev.936+fc2c1883b",
+    .minimum_zig_version = "0.15.0-dev.1034+bd97b6618",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/templates/master/src/root.zig
+++ b/templates/master/src/root.zig
@@ -5,7 +5,7 @@ pub fn bufferedPrint() !void {
     // Stdout is for the actual output of your application, for example if you
     // are implementing gzip, then only the compressed bytes should be sent to
     // stdout, not any debugging messages.
-    const stdout_file = std.io.getStdOut().writer();
+    const stdout_file = std.fs.File.stdout().deprecatedWriter();
     // Buffering can improve performance significantly in print-heavy programs.
     var bw = std.io.bufferedWriter(stdout_file);
     const stdout = bw.writer();


### PR DESCRIPTION
This should fix the issue that's currently causing automatic updates to fail