### PR TITLE
Fix Automation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,7 @@
         bundle.aws.lambda = pkgs.callPackage ./src/bundle/lambda.nix { bundleZip = bundle.zip; };
       };
 
-      test-env = zig-env { zig = zigv.master; };
+      test-env = zig-env { zig = zigv.latest; };
       test-app = test-env.app-bare;
 
       test = removeAttrs (_callPackage src/test.nix {


### PR DESCRIPTION
Currently the GitHub Action "Automation" is broken. This is caused by a zig version mismatch by compiling zig2nix with latest and creating the test-env with master. This causes the output of "zig env", which is used in zig2nix, to be zon instead of json and the parser of that output still uses the json reader. For now, this is fixed by creating the test-env with zig latest instead of master. I think this is the correct way for now, as using master would make sense when the rest of zig2nix is also upgraded to master.