### PR TITLE
zon2nix: don't use wide `with` scopes

### DIFF
--- a/src/zig2nix/src/zon2nix.zig
+++ b/src/zig2nix/src/zon2nix.zig
@@ -21,9 +21,6 @@ fn writeInternal(arena: std.mem.Allocator, lock: zon2lock.Lock, out: *std.Io.Wri
         \\  name ? "zig-packages",
         \\}:
         \\
-        \\with builtins;
-        \\with lib;
-        \\
         \\let
         \\  unpackZigArtifact = { name, artifact }:
         \\    runCommandLocal name { nativeBuildInputs = [ zig ]; }
@@ -38,9 +35,9 @@ fn writeInternal(arena: std.mem.Allocator, lock: zon2lock.Lock, out: *std.Io.Wri
         \\  in unpackZigArtifact { inherit name artifact; };
         \\
         \\  fetchGitZig = { name, url, hash, rev ? throw "rev is required, remove and regenerate the zon2json-lock file" }: let
-        \\    parts = splitString "#" url;
-        \\    url_base = elemAt parts 0;
-        \\    url_without_query = elemAt (splitString "?" url_base) 0;
+        \\    parts = lib.splitString "#" url;
+        \\    url_base = lib.elemAt parts 0;
+        \\    url_without_query = lib.elemAt (lib.splitString "?" url_base) 0;
         \\  in fetchgit {
         \\    inherit name rev hash;
         \\    url = url_without_query;
@@ -48,9 +45,9 @@ fn writeInternal(arena: std.mem.Allocator, lock: zon2lock.Lock, out: *std.Io.Wri
         \\  };
         \\
         \\  fetchZigArtifact = { name, url, hash, ... } @ args: let
-        \\    parts = splitString "://" url;
-        \\    proto = elemAt parts 0;
-        \\    path = elemAt parts 1;
+        \\    parts = lib.splitString "://" url;
+        \\    proto = lib.elemAt parts 0;
+        \\    path = lib.elemAt parts 1;
         \\    fetcher = {
         \\      "git+http" = fetchGitZig (args // {
         \\        url = "http://${path}";


### PR DESCRIPTION
This is discouraged in nixpkgs.
See: https://github.com/NixOS/nixpkgs/issues/208242
