### PR TITLE
nixfmt-rfc-style -> nixfmt

### DIFF
--- a/src/zig2nix/default.nix
+++ b/src/zig2nix/default.nix
@@ -3,7 +3,7 @@
   , stdenvNoCC
   , zig
   , git
-  , nixfmt-rfc-style
+  , nixfmt
   , nix-prefetch-git
   , nix
   , makeWrapper
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation {
     wrapProgram $out/bin/zig2nix --prefix PATH : ${lib.makeBinPath [
       git
       nix
-      nixfmt-rfc-style
+      nixfmt
       nix-prefetch-git
     ]}
   '';


### PR DESCRIPTION
This gets rid of the warning when running flake that uses zig2nix. (ingore git tree dirty)

Before:
```
~/Dev/spike: nix build
warning: Git tree '/home/pivok/Dev/spike' is dirty
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
~/Dev/spike:    
```

Now:
```
~/Dev/spike: nix build
warning: Git tree '/home/pivok/Dev/spike' is dirty
~/Dev/spike:  
```